### PR TITLE
投稿する時の画像にバリデーションを適用させた。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'faker'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'devise'
 
+gem 'activestorage-validator'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       activejob (= 6.0.5.1)
       activerecord (= 6.0.5.1)
       marcel (~> 1.0)
+    activestorage-validator (0.2.2)
+      rails (>= 6.0.4.1)
     activesupport (6.0.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -228,6 +230,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activestorage-validator
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,4 +13,6 @@ class Article < ApplicationRecord
     def display_created_at
         I18n.l(self.created_at, format: :default)
     end
+
+    validates :eyecatch, presence: true, blob: { content_type: :image }
 end


### PR DESCRIPTION
## 概要
なぜ既存のコードに変更を加えたいか
投稿する際に、画像を選択せずに投稿するとエラーが発生するため。

## 変更点
article.rbにバリデーションを適用させるコードを書いた。

## 動作確認
実際に画像を選択しないで投稿してみると、「Eyecatchを入力してください」と表示され、エラー
が表示されなくなった。
